### PR TITLE
FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES 在Android 6.0上不可用

### DIFF
--- a/automator/hidden-apis/src/main/java/android/app/UiAutomationHidden.java
+++ b/automator/hidden-apis/src/main/java/android/app/UiAutomationHidden.java
@@ -10,13 +10,6 @@ import dev.rikka.tools.refine.RefineAs;
 @SuppressWarnings("unused")
 @RefineAs(UiAutomation.class)
 public class UiAutomationHidden {
-    /**
-     * UiAutomation suppresses accessibility services by default. This flag specifies that
-     * existing accessibility services should continue to run, and that new ones may start.
-     * This flag is set when obtaining the UiAutomation from
-     * {@link android.app.Instrumentation#getUiAutomation(int)}.
-     */
-    public static final int FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES = 0x00000001;
 
     public UiAutomationHidden(Looper looper, IUiAutomationConnection connection) {
         throw new RuntimeException("Stub!");

--- a/automator/src/main/java/top/xjunz/automator/AutomatorConnection.kt
+++ b/automator/src/main/java/top/xjunz/automator/AutomatorConnection.kt
@@ -67,7 +67,12 @@ class AutomatorConnection : IAutomatorConnection.Stub() {
             log(sayHello())
             handlerThread.start()
             uiAutomationHidden = UiAutomationHidden(handlerThread.looper, UiAutomationConnection())
-            uiAutomationHidden.connect(UiAutomationHidden.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                uiAutomationHidden.connect(UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)
+            } else {
+                log("Marshmallow don't support FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES")
+                uiAutomationHidden.connect()
+            }
             log("The UiAutomation is connected at ${formatCurrentTime()}")
         } catch (t: Throwable) {
             dumpError(t)


### PR DESCRIPTION
## 改进内容
在Android 6.0上没有这个flag，也没有接收这个flag的`connect()`方法。

此外`FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES`是公共API因此不需要存根定义，况且定义之后没加`@RequiresApi`注解限定系统版本的话也无法检查。

## ~~待办事项~~
~~在这个系统版本上，启动服务会导致无障碍服务停止运行。需要进一步在UI上提醒用户。~~